### PR TITLE
Fix zero-component reconstruction dimensions and add tests

### DIFF
--- a/R/gpca.R
+++ b/R/gpca.R
@@ -779,7 +779,9 @@ reconstruct.genpca <- function(x,
                                colind = NULL) { # Default to all cols
 
   max_comp <- multivarious::ncomp(x)
-  if (max_comp == 0) return(matrix(0, nrow=length(rowind %||% 1:nrow(x$A)), ncol=length(colind %||% 1:nrow(x$M)))) # Return empty if no components
+  if (max_comp == 0) return(matrix(0,
+                                   nrow = length(rowind %||% 1:nrow(x$M)),
+                                   ncol = length(colind %||% 1:nrow(x$A)))) # Return empty if no components
   if (length(comp) == 0 || min(comp) < 1 || max(comp) > max_comp) {
       stop("Selected components 'comp' are out of bounds [1, ", max_comp, "].")
   }

--- a/tests/testthat/test_reconstruct_zero_comp.R
+++ b/tests/testthat/test_reconstruct_zero_comp.R
@@ -1,0 +1,34 @@
+library(testthat)
+library(multivarious)
+library(Matrix)
+
+context("reconstruct with zero components")
+
+test_that("reconstruct returns matrix with expected dimensions when ncomp is zero", {
+  n <- 5
+  p <- 4
+  A <- Matrix::Diagonal(p)
+  M <- Matrix::Diagonal(n)
+  obj <- multivarious::bi_projector(
+    v = matrix(0, p, 0),
+    s = matrix(0, n, 0),
+    sdev = numeric(0),
+    preproc = multivarious::pass(),
+    ov = matrix(0, p, 0),
+    ou = matrix(0, n, 0),
+    u  = matrix(0, n, 0),
+    classes = "genpca",
+    A = A,
+    M = M,
+    propv = numeric(0),
+    cumv = numeric(0)
+  )
+
+  recon_default <- reconstruct(obj)
+  expect_equal(dim(recon_default), c(n, p))
+
+  ri <- 2:4
+  ci <- c(1, 3)
+  recon_subset <- reconstruct(obj, rowind = ri, colind = ci)
+  expect_equal(dim(recon_subset), c(length(ri), length(ci)))
+})


### PR DESCRIPTION
## Summary
- correct reconstruct.genpca dimensions when `ncomp(x) == 0`
- test reconstruction output dimensions for zero-component models

## Testing
- `R CMD check` *(fails: command not found)*