### PR TITLE
Add ncomp integer check

### DIFF
--- a/R/gpca.R
+++ b/R/gpca.R
@@ -216,7 +216,8 @@ genpca <- function(X, A=NULL, M=NULL, ncomp=NULL,
   if (is.null(ncomp)) {
       ncomp <- min(dim(X))
   }
-  assert_that(ncomp > 0, msg="ncomp must be positive.")
+  assert_that(length(ncomp) == 1 && ncomp == floor(ncomp) && ncomp > 0,
+              msg="ncomp must be a single positive integer.")
   ncomp <- min(min(dim(X)), ncomp) # Cannot exceed dimensions
 
   # Prepare and validate constraints M and A

--- a/tests/testthat/test_gpca.R
+++ b/tests/testthat/test_gpca.R
@@ -3,6 +3,11 @@ context("genpca")
 mat_10_10 <- matrix(rnorm(10*10), 10, 10)
 library(multivarious)
 
+test_that("ncomp must be integer", {
+  expect_error(genpca(mat_10_10, ncomp = 2.5), "single positive integer")
+  expect_error(genpca(mat_10_10, ncomp = c(1, 2)), "single positive integer")
+})
+
 test_that("pca and genpca have same results with identity matrix for row and column constraints", {
   res1 <- genpca(mat_10_10, preproc=center())
   res2 <- pca(mat_10_10,ncomp=ncomp(res1), preproc=center())


### PR DESCRIPTION
## Summary
- validate that `ncomp` in `genpca()` is a single positive integer
- add regression test ensuring non-integer `ncomp` triggers an error

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*