### PR TITLE
Fix deflation empty return

### DIFF
--- a/R/gpca.R
+++ b/R/gpca.R
@@ -724,7 +724,12 @@ gmd_deflationR <- function(X, Q, R, k, thr = 1e-6, verbose=FALSE) {
   }
 
   if (k_found == 0) {
-      return(list(d=numeric(0), v=matrix(NA_real_, p, 0), u=matrix(NA_real_, n, 0), k=0, cumv=numeric(0), propv=numeric(0)))
+      return(list(d=numeric(0),
+                  v=matrix(0, p, 0),
+                  u=matrix(0, n, 0),
+                  k=0,
+                  cumv=numeric(0),
+                  propv=numeric(0)))
   }
 
   cumv <- cumsum(propv) # Calculate cumulative sum on valid components

--- a/tests/testthat/test_deflation_empty.R
+++ b/tests/testthat/test_deflation_empty.R
@@ -1,0 +1,30 @@
+context("gmd_deflationR empty case")
+
+library(Matrix)
+library(multivarious)
+
+# gmd_deflationR is internal
+
+test_that("gmd_deflationR returns zero-sized matrices when no components found", {
+  X <- matrix(0, 5, 4)
+  Q <- Diagonal(5)
+  R <- Diagonal(4)
+  res <- genpca:::gmd_deflationR(X, Q, R, k = 3, verbose = FALSE)
+  expect_equal(res$k, 0)
+  expect_equal(dim(res$u), c(5, 0))
+  expect_equal(dim(res$v), c(4, 0))
+  expect_equal(length(res$d), 0)
+  expect_equal(res$u, matrix(0, 5, 0))
+  expect_equal(res$v, matrix(0, 4, 0))
+})
+
+
+test_that("genpca handles zero-rank input consistently", {
+  X <- matrix(0, 6, 4)
+  fit <- genpca(X, ncomp = 3, method = "deflation", use_cpp = FALSE)
+  expect_s3_class(fit, c("genpca", "bi_projector", "projector"))
+  expect_equal(multivarious::ncomp(fit), 0)
+  expect_equal(dim(multivarious::scores(fit)), c(6, 0))
+  expect_equal(dim(multivarious::loadings(fit)), c(4, 0))
+  expect_equal(length(multivarious::sdev(fit)), 0)
+})


### PR DESCRIPTION
## Summary
- return zero-sized matrices from `gmd_deflationR` when no components are found
- exercise the zero-component path in `genpca`
- add unit tests for empty deflation results

## Testing
- `R --version` *(fails: command not found)*