### PR TITLE
Fix ncomp oversize handling

### DIFF
--- a/R/genplsc.R
+++ b/R/genplsc.R
@@ -43,7 +43,9 @@
 #' @param X,Y              Numeric matrices with identical numbers of rows.
 #' @param Mx,Ax,My,Ay      Row/column constraint matrices (NULL ⇒ identity).
 #' @param ncomp            Number of latent factors.  If \eqn{\le 0},
-#'                         uses \eqn{\min(p,q)}.
+#'                         uses \eqn{\min(p,q)}.  After computing
+#'                         `p` and `q`, any oversized value is
+#'                         trimmed to `min(ncomp, p, q)`.
 #' @param preproc_x,preproc_y  [`multivarious`] preprocessing objects
 #'                         (e.g. `center()`, `standardize()`, `pass()`).
 #' @param rank_Mx,rank_Ax,rank_My,rank_Ay
@@ -109,6 +111,7 @@ genplsc <- function(X, Y,
 
   svd_method <- match.arg(svd_method)
   n <- nrow(X); p <- ncol(X); q <- ncol(Y)
+  ncomp <- min(ncomp, p, q)  # cannot exceed matrix dimensions
 
   ## ---- 1. defaults for constraints --------------------------------
   if(is.null(Mx)) Mx <- Matrix::Diagonal(n)

--- a/R/genplsr.R
+++ b/R/genplsr.R
@@ -112,6 +112,8 @@ nipals_deflation_gs <- function(Xmat, Ymat, ncomp, maxiter=200, tol=1e-9, verbos
 #' @param My,Ay row/column constraints for \eqn{Y}, each either diagonal/identity
 #'        or PSD of size \eqn{(n \times n)/(q \times q)}. Same adaptive logic as above.
 #' @param ncomp integer, number of factors (components) to extract.
+#'   After the dimensions `p` and `q` are determined, oversized
+#'   values are reduced to `min(ncomp, p, q)`.
 #'
 #' @param preproc_x, preproc_y \code{\link[multivarious]{pre_processor}} objects or
 #'        \code{\link[multivarious]{pass}} for no preprocessing.
@@ -166,6 +168,7 @@ genpls <- function(X, Y,
   if(ncomp > approx_rank && verbose) {
     warning(sprintf("Requested ncomp=%d > min(n,p,q)=%d => degenerate?", ncomp, approx_rank))
   }
+  ncomp <- min(ncomp, p, q)  # cannot exceed dimensions
   
   # 2) Default constraints => identity if missing
   if(is.null(Mx)) Mx <- Matrix::Diagonal(n)

--- a/tests/testthat/test_genpls.R
+++ b/tests/testthat/test_genpls.R
@@ -269,3 +269,18 @@ test_that("rpls and genpls give similar results for identity constraints", {
     expect_gt(cval_scores, 0.9)
   }
 })
+
+
+test_that("genpls trims oversized ncomp to min(p, q)", {
+  set.seed(42)
+  n <- 8
+  p <- 3
+  q <- 4
+  X <- matrix(rnorm(n * p), n, p)
+  Y <- matrix(rnorm(n * q), n, q)
+
+  too_many <- 10
+  fit <- genpls(X, Y, ncomp = too_many, verbose = FALSE)
+  expect_equal(fit$ncomp, min(too_many, p, q))
+})
+

--- a/tests/testthat/test_genplscorr.R
+++ b/tests/testthat/test_genplscorr.R
@@ -788,3 +788,17 @@ test_that("genplscorr2 handles low-rank data + constraints consistently", {
   # The point is: in a low-rank scenario, we'd see that both approaches 
   # pick up somewhat similar directions, though not identical.
 })
+
+test_that("genplsc trims oversized ncomp to min(p, q)", {
+  set.seed(99)
+  n <- 6
+  p <- 2
+  q <- 3
+  X <- matrix(rnorm(n * p), n, p)
+  Y <- matrix(rnorm(n * q), n, q)
+
+  too_many <- 8
+  fit <- genplsc(X, Y, ncomp = too_many, verbose = FALSE)
+  expect_equal(fit$ncomp, min(too_many, p, q))
+})
+


### PR DESCRIPTION
## Summary
- cap `ncomp` to `min(ncomp, p, q)` in `genplsc` and `genpls`
- clarify trimming behaviour in documentation
- test oversized `ncomp` values for both functions

## Testing
- `R -q -e "devtools::test()"` *(fails: R missing)*