### PR TITLE
Add row/col likeness arg conflict check

### DIFF
--- a/R/genplsc.R
+++ b/R/genplsc.R
@@ -110,6 +110,9 @@ genplsc <- function(X, Y,
   svd_method <- match.arg(svd_method)
   n <- nrow(X); p <- ncol(X); q <- ncol(Y)
 
+  if(!is.null(force_row_likeness) && !is.null(force_col_likeness))
+    stop("Specify only one of force_row_likeness or force_col_likeness")
+
   ## ---- 1. defaults for constraints --------------------------------
   if(is.null(Mx)) Mx <- Matrix::Diagonal(n)
   if(is.null(My)) My <- Matrix::Diagonal(n)

--- a/tests/testthat/test_force_likeness_args.R
+++ b/tests/testthat/test_force_likeness_args.R
@@ -1,0 +1,16 @@
+library(testthat)
+
+# Basic numeric matrices
+set.seed(1)
+X <- matrix(rnorm(20), 5, 4)
+Y <- matrix(rnorm(15), 5, 3)
+
+# Expect an error when both force_row_likeness and force_col_likeness are set
+# simultaneously
+
+test_that("genplsc stops if both force_row_likeness and force_col_likeness are supplied", {
+  expect_error(
+    genplsc(X, Y, dual = TRUE, force_row_likeness = TRUE, force_col_likeness = TRUE),
+    "force_row_likeness"
+  )
+})


### PR DESCRIPTION
## Summary
- prevent conflicting `force_row_likeness` and `force_col_likeness`
- test for the new error behaviour

## Testing
- `Rscript -e '1+1'` *(fails: command not found)*