### PR TITLE
Fix RkM deflation update

### DIFF
--- a/R/rpls.R
+++ b/R/rpls.R
@@ -229,6 +229,10 @@ fit_rpls <- function(X, Y,
     
     # Deflate M using cached RkM
     M <- M - Rk %*% (inv_RkTRk %*% RkM) # M = M - Rk (Rk'Rk)^{-1} Rk' M
+
+    # Recompute crossprod(Rk, M) after deflation so RkM reflects the
+    # updated (deflated) M for the next iteration
+    RkM <- crossprod(Rk, M)
   } # end for K
   
   if (num_components < K) {


### PR DESCRIPTION
## Summary
- recompute cached crossproduct `RkM` after each deflation step in `fit_rpls`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`