### PR TITLE
Fix ellipsis documentation in rpls

### DIFF
--- a/R/rpls.R
+++ b/R/rpls.R
@@ -277,7 +277,8 @@ fit_rpls <- function(X, Y,
 #'   objects (see \code{\link[multivarious]{prep}}). By default they pass
 #'   the data through unchanged using \code{pass()}.
 #' @param ... Further arguments (e.g., custom stopping criteria if implemented)
-#'   are passed to \code{fit_rpls} and stored in the returned object.
+#'   are stored in the returned object (they are not used by
+#'   \code{fit_rpls}).
 #'
 #' @return An object of class \code{c("rpls","cross_projector","projector")}
 #'   with at least the elements


### PR DESCRIPTION
## Summary
- clarify that `...` arguments are only stored in the returned object

## Testing
- `R CMD build .` *(fails: `R` not found)*