### PR TITLE
Allow seed control in solve_gep_subspace

### DIFF
--- a/R/gep_subspace.R
+++ b/R/gep_subspace.R
@@ -41,6 +41,7 @@ orthonormalize <- function(X) {
 #' @param max_iter,tol Stopping rule - iteration stops when
 #'   `max(abs(λ_new - λ_old)/abs(λ_old)) < tol`.
 #' @param V0 Optional `d×q` initial block (will be orthonormalised).
+#' @param seed Optional integer seed for reproducible random initialisation.
 #' @param reg_S,reg_T Ridge terms added to `S1`/`S2` and the small
 #'   `q×q` Gram matrix to guarantee invertibility.
 #' @param verbose Logical – print convergence info.
@@ -57,8 +58,8 @@ orthonormalize <- function(X) {
 #' S2 <- crossprod(matrix(rnorm(d*d), d, d)) + Diagonal(d)*0.1
 #' S1 <- crossprod(matrix(rnorm(d*d), d, d)) + Diagonal(d)*0.1
 #' solve_gep_subspace(S1, S2, q)
-solve_gep_subspace <- function(S1, S2, q = 2, which = c("largest", "smallest"), 
-                               max_iter = 100, tol = 1e-6, V0 = NULL,
+solve_gep_subspace <- function(S1, S2, q = 2, which = c("largest", "smallest"),
+                               max_iter = 100, tol = 1e-6, V0 = NULL, seed = NULL,
                                reg_S = 1e-3, reg_T = 1e-6, verbose = FALSE) {
   which <- match.arg(which)
   d <- nrow(S1)
@@ -84,7 +85,7 @@ solve_gep_subspace <- function(S1, S2, q = 2, which = c("largest", "smallest"),
   }
   
   if (is.null(V0)) {
-    set.seed(123)
+    if (!is.null(seed)) set.seed(seed)
     V <- matrix(rnorm(d*q), d, q)
   } else {
     V <- V0


### PR DESCRIPTION
## Summary
- add a `seed` argument to `solve_gep_subspace`
- only call `set.seed()` when a seed is supplied
- document the new argument

## Testing
- `R CMD check .` *(fails: R not installed)*