### PR TITLE
Add convergence warning for nipals and unit test

### DIFF
--- a/R/genplsr.R
+++ b/R/genplsr.R
@@ -26,7 +26,8 @@ nipals_deflation_gs <- function(Xmat, Ymat, ncomp, maxiter=200, tol=1e-9, verbos
     u_n <- Yres[, jmax, drop=FALSE]
 
     valid_comp <- TRUE
-    
+    diff_val <- Inf
+
     for(iter in seq_len(maxiter)) {
       # (1) p_k
       denom_u <- sum(u_n^2)
@@ -99,6 +100,9 @@ nipals_deflation_gs <- function(Xmat, Ymat, ncomp, maxiter=200, tol=1e-9, verbos
       diff_val<- sqrt(sum((u_n_new - u_n)^2))
       u_n <- u_n_new
       if(diff_val<tol) break
+    }
+    if(valid_comp && iter == maxiter && diff_val >= tol) {
+      warning(sprintf("Component %d did not converge within %d iterations", k, maxiter))
     }
     
     if(!valid_comp) {

--- a/tests/testthat/test_genpls.R
+++ b/tests/testthat/test_genpls.R
@@ -269,3 +269,13 @@ test_that("rpls and genpls give similar results for identity constraints", {
     expect_gt(cval_scores, 0.9)
   }
 })
+
+test_that("genpls warns when NIPALS fails to converge", {
+  set.seed(42)
+  X <- matrix(rnorm(20), 10, 2)
+  Y <- matrix(rnorm(30), 10, 3)
+  expect_warning(
+    genpls(X, Y, ncomp = 1, maxiter = 1, tol = 1e-9, verbose = FALSE),
+    "did not converge"
+  )
+})


### PR DESCRIPTION
## Summary
- initialize `diff_val` before the iteration loop in `nipals_deflation_gs`
- warn when a component does not converge within the allowed iterations
- add unit test checking the convergence warning

## Testing
- `devtools::test()` *(fails: `R` not available)*