### PR TITLE
Trim zero components in genpls

### DIFF
--- a/R/genplsr.R
+++ b/R/genplsr.R
@@ -235,19 +235,21 @@ genpls <- function(X, Y,
   Ytilde <- col_transform(Yrw, Ay_sqrt)
   
   nipres <- nipals_deflation_gs(Xtilde, Ytilde, ncomp, maxiter, tol, verbose)
-  
-  Ptilde <- nipres$P
-  Qtilde <- nipres$Q
-  Ttilde <- nipres$T
-  Utilde <- nipres$U
+
+  extracted <- which(colSums(abs(nipres$P)) > tol)
+  Ptilde <- nipres$P[, extracted, drop = FALSE]
+  Qtilde <- nipres$Q[, extracted, drop = FALSE]
+  Ttilde <- nipres$T[, extracted, drop = FALSE]
+  Utilde <- nipres$U[, extracted, drop = FALSE]
+  ncomp_eff <- length(extracted)
   
   # 7) build_invsqrt_mult => from plsutils
   Ax_invsqrt <- build_invsqrt_mult(Ax, rank_Ax, var_threshold, max_k, tol=tol)
   Ay_invsqrt <- build_invsqrt_mult(Ay, rank_Ay, var_threshold, max_k, tol=tol)
   
-  vx <- vapply(seq_len(ncomp), function(j) Ax_invsqrt(Ptilde[, j]),
+  vx <- vapply(seq_len(ncomp_eff), function(j) Ax_invsqrt(Ptilde[, j]),
                numeric(nrow(Ptilde)))
-  vy <- vapply(seq_len(ncomp), function(j) Ay_invsqrt(Qtilde[, j]),
+  vy <- vapply(seq_len(ncomp_eff), function(j) Ay_invsqrt(Qtilde[, j]),
                numeric(nrow(Qtilde)))
   
   out <- cross_projector(
@@ -260,7 +262,7 @@ genpls <- function(X, Y,
     tilde_Py=Qtilde,
     tilde_Tx=Ttilde,
     tilde_Ty=Utilde,
-    ncomp=ncomp,
+    ncomp=ncomp_eff,
     rank_Mx=rank_Mx,
     rank_Ax=rank_Ax,
     rank_My=rank_My,

--- a/tests/testthat/test_genpls.R
+++ b/tests/testthat/test_genpls.R
@@ -24,6 +24,10 @@ test_that("genpls handles basic numeric input and constraints", {
   expect_s3_class(fit, c("genpls", "cross_projector", "projector"))
   expect_true(ncol(fit$vx) <= 2)
   expect_true(ncol(fit$vy) <= 2)
+  expect_equal(multivarious::ncomp(fit), ncol(fit$vx))
+  tol <- 1e-9
+  nnz <- sum(colSums(abs(fit$tilde_Px)) > tol)
+  expect_equal(multivarious::ncomp(fit), nnz)
 })
 
 test_that("genpls catches non-numeric or invalid ncomp", {
@@ -56,6 +60,9 @@ test_that("genpls runs and handles degenerate solutions gracefully", {
   fit <- genpls(X, Y, ncomp=3, verbose=TRUE)
   # might see warnings about degenerate or rank-limited
   expect_true(ncol(fit$vx) <= 3)
+  expect_equal(multivarious::ncomp(fit), ncol(fit$vx))
+  nnz <- sum(colSums(abs(fit$tilde_Px)) > 1e-9)
+  expect_equal(multivarious::ncomp(fit), nnz)
 })
 
 test_that("genpls works with adjacency-like constraints (row & col)", {


### PR DESCRIPTION
## Summary
- drop zero loadings after running the NIPALS routine in `genpls`
- return the effective component count to `cross_projector`
- test that `ncomp` equals the number of extracted non-zero components

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`